### PR TITLE
Stabilize deployment and wire up Gemini API

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,11 +21,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Use Node.js ${{ matrix.node-version }}
+      if: hashFiles('package-lock.json') != ''
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+
+    - name: Install dependencies
+      run: npm ci
+      if: hashFiles('package-lock.json') != ''
+
+    - name: Build
+      run: npm run build --if-present
+      if: hashFiles('package-lock.json') != ''
+
+    - name: Test
+      run: npm test
+      if: hashFiles('package-lock.json') != ''
+
+    - name: Static site - no build needed
+      run: echo "No Node.js build necessary"
+      if: hashFiles('package-lock.json') == ''

--- a/index.html
+++ b/index.html
@@ -223,7 +223,8 @@
               href="YOUR_TELEGRAM_CHANNEL_LINK_HERE"
               target="_blank"
               id="telegram-link"
-              >[ Open Secure Comms Channel ]</a
+              class="btn lowkey-glow"
+              >Open Secure Comms Channel</a
             >
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -254,7 +254,7 @@ window.addEventListener("load", () => {
       try {
         let chatHistory = [{ role: "user", parts: [{ text: fullPrompt }] }];
         const payload = { contents: chatHistory };
-        const apiKey = ""; // IMPORTANT: Replace with your own Gemini API Key for live deployment
+        const apiKey = "AIzaSyBK2R2tg5pifniF-8toXIp_KSCEs2XAMXw"; // Gemini API key
         const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
 
         const response = await fetch(apiUrl, {

--- a/styles.css
+++ b/styles.css
@@ -360,19 +360,11 @@ body {
 /* New Telegram Link Styling */
 #telegram-link {
   display: block;
+  width: max-content;
+  margin: 3rem auto 0;
+  font-size: 1.25rem;
+  padding: 1.5rem 3rem;
   text-align: center;
-  margin-top: 3rem;
-  color: #666;
-  font-family: var(--font-primary);
-  text-decoration: none;
-  letter-spacing: 1px;
-  transition:
-    color 0.3s,
-    text-shadow 0.3s;
-}
-#telegram-link:hover {
-  color: var(--color-gold);
-  text-shadow: 0 0 10px var(--color-gold);
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- Skip Node-related steps in CI when no package-lock exists to prevent empty builds from failing
- Add Gemini API key for the Oracle tool
- Make Telegram channel call-to-action a prominent button

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689928485c58832683b1bfe1ec1652a5